### PR TITLE
Add a graph layout algorithm

### DIFF
--- a/Foreman/Foreman.csproj
+++ b/Foreman/Foreman.csproj
@@ -113,6 +113,9 @@
     <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
     </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -210,6 +213,8 @@
     </Compile>
     <Compile Include="Models\AssemblerSelector.cs" />
     <Compile Include="Models\FuelSelector.cs" />
+    <Compile Include="Models\Layout\GraphLayout.cs" />
+    <Compile Include="Models\Layout\CoordinateAssignment.cs" />
     <Compile Include="Models\LinkChecker.cs" />
     <Compile Include="Models\ModuleSelector.cs" />
     <Compile Include="Models\Nodes\ConsumerNode.cs" />

--- a/Foreman/Forms/MainForm.Designer.cs
+++ b/Foreman/Forms/MainForm.Designer.cs
@@ -571,27 +571,27 @@
 		}
 
 		#endregion
-        private System.Windows.Forms.TableLayoutPanel MainLayoutPanel;
-        private System.Windows.Forms.Button SaveAsGraphButton;
-        private System.Windows.Forms.Button LoadGraphButton;
-        private System.Windows.Forms.Button NewGraphButton;
-        private System.Windows.Forms.Button EnableDisableButton;
-        private System.Windows.Forms.Button ExportImageButton;
-        private System.Windows.Forms.Button ImportGraphButton;
-        private System.Windows.Forms.GroupBox ProductionGroupBox;
-        private System.Windows.Forms.CheckBox PauseUpdatesCheckbox;
-        private System.Windows.Forms.ComboBox RateOptionsDropDown;
-        private System.Windows.Forms.GroupBox GridLinesGroupBox;
-        private System.Windows.Forms.Button AlignSelectionButton;
-        private System.Windows.Forms.CheckBox GridlinesCheckbox;
-        private System.Windows.Forms.Label label3;
-        private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.ComboBox MajorGridlinesDropDown;
-        private System.Windows.Forms.ComboBox MinorGridlinesDropDown;
-        private ProductionGraphViewer GraphViewer;
-        private System.Windows.Forms.Button AddItemButton;
-        private System.Windows.Forms.Button AddRecipeButton;
-        private System.Windows.Forms.Label label4;
+		private System.Windows.Forms.TableLayoutPanel MainLayoutPanel;
+		private System.Windows.Forms.Button SaveAsGraphButton;
+		private System.Windows.Forms.Button LoadGraphButton;
+		private System.Windows.Forms.Button NewGraphButton;
+		private System.Windows.Forms.Button EnableDisableButton;
+		private System.Windows.Forms.Button ExportImageButton;
+		private System.Windows.Forms.Button ImportGraphButton;
+		private System.Windows.Forms.GroupBox ProductionGroupBox;
+		private System.Windows.Forms.CheckBox PauseUpdatesCheckbox;
+		private System.Windows.Forms.ComboBox RateOptionsDropDown;
+		private System.Windows.Forms.GroupBox GridLinesGroupBox;
+		private System.Windows.Forms.Button AlignSelectionButton;
+		private System.Windows.Forms.CheckBox GridlinesCheckbox;
+		private System.Windows.Forms.Label label3;
+		private System.Windows.Forms.Label label2;
+		private System.Windows.Forms.ComboBox MajorGridlinesDropDown;
+		private System.Windows.Forms.ComboBox MinorGridlinesDropDown;
+		private ProductionGraphViewer GraphViewer;
+		private System.Windows.Forms.Button AddItemButton;
+		private System.Windows.Forms.Button AddRecipeButton;
+		private System.Windows.Forms.Label label4;
 		private System.Windows.Forms.TableLayoutPanel MenuTable;
 		private System.Windows.Forms.TableLayoutPanel MenuButtonsTable;
 		private System.Windows.Forms.TableLayoutPanel GraphOptionsTable;

--- a/Foreman/Forms/MainForm.Designer.cs
+++ b/Foreman/Forms/MainForm.Designer.cs
@@ -56,6 +56,10 @@
 			this.label4 = new System.Windows.Forms.Label();
 			this.PauseUpdatesCheckbox = new System.Windows.Forms.CheckBox();
 			this.GraphSummaryButton = new System.Windows.Forms.Button();
+			this.GraphLayoutGroupBox = new System.Windows.Forms.GroupBox();
+			this.GraphLayoutTable = new System.Windows.Forms.TableLayoutPanel();
+			this.LayoutGraphButton = new System.Windows.Forms.Button();
+			this.ReduceCrossingsCheckBox = new System.Windows.Forms.CheckBox();
 			this.VersionLabel = new System.Windows.Forms.Label();
 			this.MainLayoutPanel.SuspendLayout();
 			this.MenuTable.SuspendLayout();
@@ -64,6 +68,8 @@
 			this.GridlinesTable.SuspendLayout();
 			this.ProductionGroupBox.SuspendLayout();
 			this.GraphOptionsTable.SuspendLayout();
+			this.GraphLayoutGroupBox.SuspendLayout();
+			this.GraphLayoutTable.SuspendLayout();
 			this.SuspendLayout();
 			// 
 			// MainLayoutPanel
@@ -115,12 +121,13 @@
 			this.MenuTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
 			this.MenuTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
 			this.MenuTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-			this.MenuTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-			this.MenuTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+			this.MenuTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this.MenuTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
 			this.MenuTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
 			this.MenuTable.Controls.Add(this.MenuButtonsTable, 0, 0);
 			this.MenuTable.Controls.Add(this.GridLinesGroupBox, 1, 0);
 			this.MenuTable.Controls.Add(this.ProductionGroupBox, 2, 0);
+			this.MenuTable.Controls.Add(this.GraphLayoutGroupBox, 3, 0);
 			this.MenuTable.Controls.Add(this.VersionLabel, 5, 0);
 			this.MenuTable.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.MenuTable.Location = new System.Drawing.Point(3, 3);
@@ -526,13 +533,72 @@
 			this.GraphSummaryButton.UseVisualStyleBackColor = true;
 			this.GraphSummaryButton.Click += new System.EventHandler(this.GraphSummaryButton_Click);
 			// 
+			// GraphLayoutGroupBox
+			// 
+			this.GraphLayoutGroupBox.AutoSize = true;
+			this.GraphLayoutGroupBox.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+			this.GraphLayoutGroupBox.Controls.Add(this.GraphLayoutTable);
+			this.GraphLayoutGroupBox.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.GraphLayoutGroupBox.Location = new System.Drawing.Point(664, 3);
+			this.GraphLayoutGroupBox.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+			this.GraphLayoutGroupBox.Name = "GraphLayoutGroupBox";
+			this.GraphLayoutGroupBox.Padding = new System.Windows.Forms.Padding(0);
+			this.GraphLayoutGroupBox.Size = new System.Drawing.Size(126, 122);
+			this.GraphLayoutGroupBox.TabIndex = 19;
+			this.GraphLayoutGroupBox.TabStop = false;
+			this.GraphLayoutGroupBox.Text = "Layout [EXP]";
+			// 
+			// GraphLayoutTable
+			// 
+			this.GraphLayoutTable.AutoSize = true;
+			this.GraphLayoutTable.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+			this.GraphLayoutTable.ColumnCount = 2;
+			this.GraphLayoutTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this.GraphLayoutTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this.GraphLayoutTable.Controls.Add(this.LayoutGraphButton, 0, 0);
+			this.GraphLayoutTable.Controls.Add(this.ReduceCrossingsCheckBox, 0, 2);
+			this.GraphLayoutTable.Location = new System.Drawing.Point(3, 16);
+			this.GraphLayoutTable.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
+			this.GraphLayoutTable.Name = "GraphLayoutTable";
+			this.GraphLayoutTable.RowCount = 4;
+			this.GraphLayoutTable.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.GraphLayoutTable.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.GraphLayoutTable.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.GraphLayoutTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+			this.GraphLayoutTable.Size = new System.Drawing.Size(120, 66);
+			this.GraphLayoutTable.TabIndex = 1;
+			// 
+			// LayoutGraphButton
+			// 
+			this.LayoutGraphButton.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.LayoutGraphButton.Location = new System.Drawing.Point(3, 3);
+			this.LayoutGraphButton.Name = "LayoutGraphButton";
+			this.LayoutGraphButton.Size = new System.Drawing.Size(114, 23);
+			this.LayoutGraphButton.TabIndex = 1;
+			this.LayoutGraphButton.Text = "Layout Graph";
+			this.LayoutGraphButton.UseVisualStyleBackColor = true;
+			this.LayoutGraphButton.Click += new System.EventHandler(this.LayoutGraphButton_Click);
+			// 
+			// ReduceCrossingsCheckBox
+			// 
+			this.ReduceCrossingsCheckBox.AutoSize = true;
+			this.ReduceCrossingsCheckBox.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.ReduceCrossingsCheckBox.Location = new System.Drawing.Point(3, 29);
+			this.ReduceCrossingsCheckBox.Margin = new System.Windows.Forms.Padding(3, 0, 3, 0);
+			this.ReduceCrossingsCheckBox.Name = "ReduceCrossingsCheckBox";
+			this.ReduceCrossingsCheckBox.Size = new System.Drawing.Size(114, 17);
+			this.ReduceCrossingsCheckBox.TabIndex = 3;
+			this.ReduceCrossingsCheckBox.Text = "Reduce Crossings";
+			this.ReduceCrossingsCheckBox.UseVisualStyleBackColor = true;
+			this.ReduceCrossingsCheckBox.CheckedChanged += new System.EventHandler(this.ReduceCrossingsCheckBox_CheckedChanged);
+			// 
 			// VersionLabel
 			// 
 			this.VersionLabel.AutoSize = true;
 			this.VersionLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.VersionLabel.Location = new System.Drawing.Point(810, 0);
+			this.VersionLabel.Location = new System.Drawing.Point(811, 0);
 			this.VersionLabel.Name = "VersionLabel";
-			this.VersionLabel.Size = new System.Drawing.Size(115, 130);
+			this.VersionLabel.Size = new System.Drawing.Size(114, 130);
 			this.VersionLabel.TabIndex = 18;
 			this.VersionLabel.Text = "Foreman v2.0 - dev.12";
 			this.VersionLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -566,6 +632,10 @@
 			this.ProductionGroupBox.PerformLayout();
 			this.GraphOptionsTable.ResumeLayout(false);
 			this.GraphOptionsTable.PerformLayout();
+			this.GraphLayoutGroupBox.ResumeLayout(false);
+			this.GraphLayoutGroupBox.PerformLayout();
+			this.GraphLayoutTable.ResumeLayout(false);
+			this.GraphLayoutTable.PerformLayout();
 			this.ResumeLayout(false);
 
 		}
@@ -600,6 +670,10 @@
 		private System.Windows.Forms.CheckBox IconViewCheckBox;
 		private System.Windows.Forms.Label VersionLabel;
 		private System.Windows.Forms.Button SaveButton;
+		private System.Windows.Forms.Button LayoutGraphButton;
+		private System.Windows.Forms.GroupBox GraphLayoutGroupBox;
+		private System.Windows.Forms.TableLayoutPanel GraphLayoutTable;
+		private System.Windows.Forms.CheckBox ReduceCrossingsCheckBox;
 	}
 }
 

--- a/Foreman/Forms/MainForm.cs
+++ b/Foreman/Forms/MainForm.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Windows.Forms;
-using System.IO;
-using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Text;
+using System.Windows.Forms;
 
 namespace Foreman
 {
@@ -402,7 +402,7 @@ namespace Foreman
 							beacon.Enabled = options.EnabledObjects.Contains(beacon);
 						foreach (Module module in GraphViewer.DCache.Modules.Values)
 							module.Enabled = options.EnabledObjects.Contains(module);
-						GraphViewer.DCache.RocketAssembler.Enabled = GraphViewer.DCache.Assemblers["rocket-silo"]?.Enabled?? false;
+						GraphViewer.DCache.RocketAssembler.Enabled = GraphViewer.DCache.Assemblers["rocket-silo"]?.Enabled ?? false;
 					}
 
 					GraphViewer.LevelOfDetail = options.LevelOfDetail;
@@ -490,7 +490,7 @@ namespace Foreman
 
 		private void MainForm_KeyDown(object sender, KeyEventArgs e)
 		{
-			if(e.KeyCode == Keys.S && (Control.ModifierKeys & Keys.Control) == Keys.Control)
+			if (e.KeyCode == Keys.S && (Control.ModifierKeys & Keys.Control) == Keys.Control)
 				if (savefilePath == null || !SaveGraph(savefilePath))
 					SaveGraphAs();
 		}
@@ -602,8 +602,8 @@ namespace Foreman
 			if (SystemInformation.TerminalServerSession)
 				return;
 			System.Reflection.PropertyInfo aProp = typeof(Control).GetProperty("DoubleBuffered",
-				System.Reflection.BindingFlags.NonPublic |
-				System.Reflection.BindingFlags.Instance);
+							System.Reflection.BindingFlags.NonPublic |
+							System.Reflection.BindingFlags.Instance);
 			aProp.SetValue(c, true, null);
 		}
 

--- a/Foreman/Forms/MainForm.cs
+++ b/Foreman/Forms/MainForm.cs
@@ -595,6 +595,18 @@ namespace Foreman
 			}
 		}
 
+		//---------------------------------------------------------Graph layout
+
+		private void LayoutGraphButton_Click(object sender, EventArgs e)
+		{
+			GraphViewer.LayoutGraph();
+		}
+
+		private void ReduceCrossingsCheckBox_CheckedChanged(object sender, EventArgs e)
+		{
+			GraphViewer.ReduceCrossings = ReduceCrossingsCheckBox.Checked;
+		}
+
 		//---------------------------------------------------------double buffering commands
 
 		public static void SetDoubleBuffered(Control c)

--- a/Foreman/Models/Layout/CoordinateAssignment.cs
+++ b/Foreman/Models/Layout/CoordinateAssignment.cs
@@ -1,0 +1,240 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+
+namespace Foreman
+{
+	/// <summary>
+	/// A graph whose nodes have been assigned to a list of ordered layers.
+	/// </summary>
+	/// <typeparam name="N">the type of the graph nodes</typeparam>
+	/// <see cref="CoordinateAssignment"/>
+	public interface ILayeredGraph<N>
+	{
+		int Height { get; }
+		int Width(int i);
+
+		IEnumerable<N> Nodes { get; }
+		N this[int i, int j] { get; }
+
+		IEnumerable<N> UpperNeighbors(N node);
+		IEnumerable<N> LowerNeighbors(N node);
+
+		bool IsBend(N node);
+
+		int Pos(N node);
+		int Layer(N node);
+	}
+
+	/// <summary>
+	/// Implementation of an algorithm by Ulrik Brandes and Boris Köpf:
+	/// "Fast and Simple Horizontal Coordinate Assignment".
+	/// </summary>
+	/// 
+	/// <see href="http://nbn-resolving.de/urn:nbn:de:bsz:352-opus-73381"/>
+	/// <see href="https://dx.doi.org/10.1007/3-540-45848-4_3">
+	public class CoordinateAssignment
+	{
+		/// <summary>
+		/// A graph adapter that allows to view a graph with left/right or top/down inverted.
+		/// </summary>
+		/// <typeparam name="N">the type of the graph nodes</typeparam>
+		private class FlippedGraph<N> : ILayeredGraph<N>
+		{
+			private readonly ILayeredGraph<N> graph;
+			private readonly bool vFlip, hFlip;
+
+			public FlippedGraph(ILayeredGraph<N> underlying, bool vFlip, bool hFlip)
+			{
+				this.graph = underlying;
+				this.vFlip = vFlip;
+				this.hFlip = hFlip;
+			}
+
+			public int Height => graph.Height;
+			public int Width(int i) => graph.Width(V(i));
+
+			public IEnumerable<N> Nodes => graph.Nodes;
+			public N this[int i, int j] => graph[V(i), H(i, j)];
+
+			public IEnumerable<N> UpperNeighbors(N node) => vFlip ? graph.LowerNeighbors(node) : graph.UpperNeighbors(node);
+			public IEnumerable<N> LowerNeighbors(N node) => vFlip ? graph.UpperNeighbors(node) : graph.LowerNeighbors(node);
+
+			public bool IsBend(N node) => graph.IsBend(node);
+
+			public int Pos(N node) => H(Layer(node), graph.Pos(node));
+			public int Layer(N node) => V(graph.Layer(node));
+
+			int V(int i) => vFlip ? Height + 1 - i : i;
+			int H(int i, int j) => hFlip ? Width(i) + 1 - j : j;
+		}
+
+		/// <summary>
+		/// Computes coordinates for a layered graph.
+		/// </summary>
+		/// <typeparam name="N">the type of the graph nodes</typeparam>
+		/// <param name="graph">the graph</param>
+		/// <param name="nodeWidth">a function that returns the width of a node</param>
+		/// <returns>a dictionary that contains coordinates for all nodes</returns>
+		public IDictionary<N, Point> AssignCoordinates<N>(ILayeredGraph<N> graph, Func<N, int> nodeWidth) where N : class
+		{
+			var layouts = new Dictionary<(bool, bool), Dictionary<N, int>>();
+
+			foreach (var vFlip in new[] { false, true })
+			{
+				foreach (var hFlip in new[] { false, true })
+				{
+					var flipped = new FlippedGraph<N>(graph, vFlip, hFlip);
+					var markedSegments = MarkType1Conflicts(flipped);
+					var (root, align) = VerticalAlignment(flipped, markedSegments);
+					layouts[(vFlip, hFlip)] = HorizontalCompaction(flipped, root, align, nodeWidth);
+				}
+			}
+
+			var minWidth = layouts.Values.Select(l => l.Values.DefaultIfEmpty(0).Max()).Min();
+
+			int x(N node)
+			{
+				return new[] {
+					layouts[(false, false)][node],
+					minWidth - layouts[(false, true)][node],
+					layouts[(true, false)][node],
+					minWidth - layouts[(true, true)][node]
+				}.OrderBy(val => val).Skip(1).Take(2).Sum() / 2;
+			}
+
+			return graph.Nodes.ToDictionary(
+				node => node,
+				node => new Point(x(node), 192 * graph.Layer(node))); // TODO: Make vertical distance configurable
+		}
+
+		private IEnumerable<int> Range(int from, int to) => (to < from) ? Enumerable.Empty<int>() : Enumerable.Range(from, to - from + 1);
+
+		private HashSet<(N, N)> MarkType1Conflicts<N>(ILayeredGraph<N> graph)
+		{
+			var markedSegments = new HashSet<(N, N)>();
+
+			foreach (var i in Range(2, graph.Height - 2))
+			{
+				int k0 = 0, l = 1;
+
+				foreach (var l1 in Range(1, graph.Width(i + 1)))
+				{
+					var vl1 = graph[i + 1, l1];
+					var incidentToInnerSegment =
+						graph.IsBend(vl1) &&
+						graph.IsBend(graph.UpperNeighbors(vl1).Single());
+
+					if (l1 == graph.Width(i + 1) || incidentToInnerSegment)
+					{
+						var k1 = graph.Width(i);
+
+						if (incidentToInnerSegment)
+							k1 = graph.Pos(graph.UpperNeighbors(vl1).Single());
+
+						while (l < l1)
+						{
+							foreach (var vik in graph.UpperNeighbors(graph[i + 1, l]))
+								if (graph.Pos(vik) < k0 || graph.Pos(vik) > k1) markedSegments.Add((vik, graph[i + 1, l]));
+
+							++l;
+						}
+
+						k0 = k1;
+					}
+				}
+			}
+
+			return markedSegments;
+		}
+
+		private IEnumerable<N> Middle<N>(ILayeredGraph<N> graph, IEnumerable<N> nodes)
+		{
+			var neighbors = nodes.OrderBy(v => graph.Pos(v)).ToList();
+			var l = neighbors.Count;
+
+			if (l > 0)
+			{
+				if (l % 2 == 0) yield return neighbors[(l - 1) / 2];
+				yield return neighbors[l / 2];
+			}
+		}
+
+		private (Dictionary<N, N>, Dictionary<N, N>) VerticalAlignment<N>(ILayeredGraph<N> graph, HashSet<(N, N)> markedSegments) where N : class
+		{
+			var root = graph.Nodes.ToDictionary(v => v);
+			var align = graph.Nodes.ToDictionary(v => v);
+
+			foreach (var i in Range(1, graph.Height))
+			{
+				var r = 0;
+				foreach (var k in Range(1, graph.Width(i)))
+				{
+					var vik = graph[i, k];
+					foreach (var um in Middle(graph, graph.UpperNeighbors(vik)))
+					{
+						if (align[vik] == vik)
+						{
+							if (!markedSegments.Contains((um, vik)) && r < graph.Pos(um))
+							{
+								align[um] = vik;
+								root[vik] = root[um];
+								align[vik] = root[vik];
+								r = graph.Pos(um);
+							}
+						}
+					}
+				}
+			}
+
+			return (root, align);
+		}
+
+		private Dictionary<N, int> HorizontalCompaction<N>(ILayeredGraph<N> graph, Dictionary<N, N> root, Dictionary<N, N> align, Func<N, int> nodeWidth) where N : class
+		{
+			var sink = graph.Nodes.ToDictionary(v => v);
+			var shift = graph.Nodes.ToDictionary(v => v, v => int.MaxValue);
+			var x = new Dictionary<N, int>();
+
+			void placeBlock(N v)
+			{
+				if (!x.ContainsKey(v))
+				{
+					x[v] = 0;
+					var w = v;
+
+					do
+					{
+						if (graph.Pos(w) > 1)
+						{
+							var predW = graph[graph.Layer(w), graph.Pos(w) - 1];
+							var delta = (nodeWidth(w) + nodeWidth(predW)) / 2;
+
+							var u = root[predW];
+							placeBlock(u);
+							if (sink[v] == v) sink[v] = sink[u];
+							if (sink[v] != sink[u])
+								shift[sink[u]] = Math.Min(shift[sink[u]], x[v] - x[u] - delta);
+							else
+								x[v] = Math.Max(x[v], x[u] + delta);
+						}
+						w = align[w];
+					} while (w != v);
+				}
+			}
+
+			foreach (var v in graph.Nodes)
+				if (root[v] == v) placeBlock(v);
+
+			foreach (var v in graph.Nodes)
+			{
+				x[v] = x[root[v]];
+				if (shift[sink[root[v]]] < int.MaxValue)
+					x[v] = x[v] + shift[sink[root[v]]];
+			}
+
+			return x;
+		}
+	}
+}

--- a/Foreman/Models/Layout/GraphLayout.cs
+++ b/Foreman/Models/Layout/GraphLayout.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+
+namespace Foreman
+{
+	public partial class ProductionGraph
+	{
+		/// <summary>
+		/// A directed graph where the nodes have been assigned to layers.
+		/// <para>This class uses 1-based indexing like the Brandes/Köpf algorithm</para>>
+		/// </summary>
+		private class LayeredGraph : ILayeredGraph<LayeredGraph.Node>
+		{
+			public class Node
+			{
+				public ReadOnlyBaseNode BaseNode { get; }
+				public int Layer { get; }
+				public int Pos { get; set; }
+
+				public Node(ReadOnlyBaseNode node, int layer) { BaseNode = node; Layer = layer; }
+			}
+
+			private readonly IDictionary<ReadOnlyBaseNode, Node> nodes;
+			private readonly List<List<Node>> layers;
+
+			public LayeredGraph(Dictionary<ReadOnlyBaseNode, int> layering)
+			{
+				nodes = layering
+					.ToDictionary(n => n.Key, n => new Node(n.Key, n.Value));
+
+				layers = nodes.Values
+					.GroupBy(Layer)
+					.OrderBy(layer => layer.Key)
+					.Select(layer => layer.OrderBy(n => n.BaseNode.Location.X).Select(UpdatePos).ToList())
+					.ToList();
+			}
+
+			public int Height => layers.Count();
+			public int Width(int i) => layers[i - 1].Count();
+
+			public IEnumerable<Node> Nodes => nodes.Values;
+			public Node this[int i, int j] => layers[i - 1][j - 1];
+
+			public IEnumerable<Node> UpperNeighbors(Node node) => Neigbors(node, NodeDirection.Up);
+			public IEnumerable<Node> LowerNeighbors(Node node) => Neigbors(node, NodeDirection.Down);
+
+			public bool IsBend(Node node) => ProductionGraph.IsBend(node.BaseNode);
+
+			public int Pos(Node node) => node.Pos;
+			public int Layer(Node node) => node.Layer;
+
+			public Node this[ReadOnlyBaseNode node] => nodes[node];
+
+			private IEnumerable<Node> Neigbors(Node node, NodeDirection direction)
+			{
+				return node.BaseNode.NodeDirection == direction
+					? node.BaseNode.OutputLinks.Select(l => nodes[l.Consumer])
+					: node.BaseNode.InputLinks.Select(l => nodes[l.Supplier]);
+			}
+
+			private static Node UpdatePos(Node n, int i)
+			{
+				n.Pos = i + 1;
+				return n;
+			}
+
+			public void ReduceCrossings()
+			{
+				if (Height > 0)
+				{
+					foreach (var i in Enumerable.Range(1, Height - 1))
+						layers[i] = layers[i].OrderBy(e => UpperNeighbors(e).Select(Pos).DefaultIfEmpty(0).Average()).Select(UpdatePos).ToList();
+
+					foreach (var i in Enumerable.Range(0, Height - 1).Reverse())
+						layers[i] = layers[i].OrderBy(e => LowerNeighbors(e).Select(Pos).DefaultIfEmpty(0).Average()).Select(UpdatePos).ToList();
+				}
+			}
+		}
+
+		private Dictionary<ReadOnlyBaseNode, int> Normalize()
+		{
+			var layering = new Dictionary<ReadOnlyBaseNode, int>();
+			var callStack = new HashSet<ReadOnlyBaseNode>();
+
+			int ComputeLayer(ReadOnlyBaseNode node)
+			{
+				while (true)
+				{
+					var consumers = node.OutputLinks.Select(l => l.Consumer).ToList();
+
+					if (consumers.Count() == 0)
+						return 1;
+
+					var maxConsumerLayer = consumers.Select(GetLayer).Max();
+					var maxConsumers = consumers.Where(c => GetLayer(c) == maxConsumerLayer).ToList();
+
+					if (IsBend(node) || !maxConsumers.All(IsBend))
+						return maxConsumerLayer + 1;
+
+					// Remove extraneous passthrough nodes. If we get here, then all predecessors of the
+					// current node are bends. We delete them and start over.
+					// We don't just delete all bends, even if they would be recreated below to keep the
+					// layout more stable.
+					foreach (var consumer in maxConsumers)
+					{
+						(RequestNodeController(consumer) as PassthroughNodeController).JoinLinks();
+						layering.Remove(consumer);
+					}
+				}
+			}
+
+			int GetLayer(ReadOnlyBaseNode node)
+			{
+				// Break cycles: the current node is already on the call stack we have detected a cycle.
+				// We just return 0 (to not unnecessarily shift down other nodes) and rely on the other
+				// call further up the call stack to return a more useful layer. This is pretty arbitrary,
+				// but at least it prevents infinite loops.
+				if (callStack.Contains(node)) return 0;
+				callStack.Add(node);
+
+				if (!layering.ContainsKey(node))
+					layering[node] = ComputeLayer(node);
+
+				callStack.Remove(node);
+				return layering[node];
+			}
+
+			// Visit nodes at the bottom before nodes that are further up. For acyclic graphs this makes
+			// no difference, but for cyclic graphs it keeps the layout more stable and gives the user
+			// limited control about where to break the cycle by rearranging the nodes. This isn't very
+			// flexible, but it's better than nothing.
+			foreach (var node in Nodes.OrderByDescending(n => n.Location.Y))
+				GetLayer(node);
+
+			// Add additional passthrough nodes to ensure all node links span only one layer.
+			foreach (var link in NodeLinks.ToList())
+			{
+				var i1 = GetLayer(link.Consumer);
+				var i2 = GetLayer(link.Supplier);
+
+				if (i2 - i1 > 1)
+				{
+					var consumer = link.Consumer;
+					foreach (var i in Enumerable.Range(i1 + 1, i2 - i1 - 1))
+					{
+						var passthrough = CreatePassthroughNode(link.Item, new Point(0, 0)); // TODO: Chose a better startup coordinate
+						(RequestNodeController(passthrough) as PassthroughNodeController).SetSimpleDraw(true);
+						layering[passthrough] = i;
+						CreateLink(passthrough, consumer, link.Item);
+						consumer = passthrough;
+					}
+					CreateLink(link.Supplier, consumer, link.Item);
+					DeleteLink(link);
+				}
+			}
+
+			return layering;
+		}
+
+		public void LayoutGraph(bool reduceCrossings, Func<ReadOnlyBaseNode, int> nodeWidth)
+		{
+			var graph = new LayeredGraph(Normalize());
+
+			if (reduceCrossings)
+				graph.ReduceCrossings();
+
+			var locations = new CoordinateAssignment().AssignCoordinates(graph, n => nodeWidth(n.BaseNode));
+
+			// TODO: Should we really just ignore if there is no controller?
+			// This is probably because we're calling the layouter at the wrong time...
+			foreach (var node in graph.Nodes)
+				RequestNodeController(node.BaseNode)?.SetLocation(locations[node]);
+		}
+
+		private static bool IsBend(ReadOnlyBaseNode node) =>
+			node is ReadOnlyPassthroughNode passthrough && passthrough.SimpleDraw &&
+			node.InputLinks.Count() == 1 &&
+			node.OutputLinks.Count() == 1;
+	}
+}
+

--- a/Foreman/Models/Nodes/PassthroughNode.cs
+++ b/Foreman/Models/Nodes/PassthroughNode.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.Serialization;
 
 namespace Foreman
@@ -103,5 +104,15 @@ namespace Foreman
 		}
 
 		public override Dictionary<string, Action> GetWarningResolutions() { Trace.Fail("Passthrough node never has the warning state!"); return null; }
+
+		public ReadOnlyNodeLink JoinLinks()
+		{
+			var link = MyNode.MyGraph.CreateLink(
+				MyNode.InputLinks.Single().SupplierNode.ReadOnlyNode,
+				MyNode.OutputLinks.Single().ConsumerNode.ReadOnlyNode,
+				MyNode.PassthroughItem); ;
+			Delete();
+			return link;
+		}
 	}
 }

--- a/Foreman/ProductionGraphView/ProductionGraphViewer.cs
+++ b/Foreman/ProductionGraphView/ProductionGraphViewer.cs
@@ -36,7 +36,7 @@ namespace Foreman
 		public bool DynamicLinkWidth = false;
 		public bool LockedRecipeEditPanelPosition = true;
 		public bool FlagOUSuppliedNodes = false; //if true, will add a flag for over or under supplied nodes
-
+		public bool ReduceCrossings = false;
 		public bool SmartNodeDirection { get; set; }
 
 		public DataCache DCache { get; set; }
@@ -539,6 +539,13 @@ namespace Foreman
 			e.Graphics.TranslateTransform(ViewOffset.X, ViewOffset.Y);
 
 			Paint(e.Graphics, false);
+		}
+
+		public void LayoutGraph()
+		{
+			// TODO: Make the passthrough width configurable
+			Graph.LayoutGraph(ReduceCrossings, n => (n is ReadOnlyPassthroughNode passthrough && passthrough.SimpleDraw) ? 48 : 24 + nodeElementDictionary[n].Width);
+			UpdateNodeVisuals();
 		}
 
 		public new void Paint(Graphics graphics, bool FullGraph = false)

--- a/Foreman/ProductionGraphView/ProductionGraphViewer.cs
+++ b/Foreman/ProductionGraphView/ProductionGraphViewer.cs
@@ -1,16 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Windows.Forms;
-using System.Runtime.Serialization;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Data;
 using System.Diagnostics;
-using Newtonsoft.Json;
-using System.Text;
+using System.Drawing;
 using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace Foreman
 {
@@ -27,7 +27,7 @@ namespace Foreman
 		public bool ArrowsOnLinks { get; set; }
 		public bool IconsOnly { get; set; }
 		public int IconsSize { get; set; }
-		public int IconsDrawSize { get { return ViewScale > ((double)IconsSize / 96)? 96 : (int)(IconsSize / ViewScale); } }
+		public int IconsDrawSize { get { return ViewScale > ((double)IconsSize / 96) ? 96 : (int)(IconsSize / ViewScale); } }
 
 		public int NodeCountForSimpleView { get; set; } //if the number of elements to draw is over this amount then the drawing functions will switch to simple view draws (mostly for FPS during zoomed out views)
 		public bool ShowRecipeToolTip { get; set; }
@@ -186,7 +186,7 @@ namespace Foreman
 
 		public void AddRecipe(Point drawOrigin, Item baseItem, Point newLocation, NewNodeType nNodeType, BaseNodeElement originElement = null, bool offsetLocationToItemTabLevel = false)
 		{
-			if(string.IsNullOrEmpty(DCache.PresetName))
+			if (string.IsNullOrEmpty(DCache.PresetName))
 			{
 				DisposeLinkDrag();
 				MessageBox.Show("The current preset (" + Properties.Settings.Default.CurrentPresetName + ") is corrupt.");
@@ -195,14 +195,14 @@ namespace Foreman
 
 			if ((nNodeType != NewNodeType.Disconnected) && (originElement == null || baseItem == null))
 				Trace.Fail("Origin element or base item not provided for a new (linked) node");
-			
+
 			if (Grid.ShowGrid)
 				newLocation = Grid.AlignToGrid(newLocation);
 
 			int lastNodeWidth = 0;
 			NodeDirection newNodeDirection = (originElement == null || !SmartNodeDirection) ? Graph.DefaultNodeDirection :
-				draggedLinkElement.Type != BaseLinkElement.LineType.UShape ? originElement.DisplayedNode.NodeDirection :
-				originElement.DisplayedNode.NodeDirection == NodeDirection.Up ? NodeDirection.Down : NodeDirection.Up;
+							draggedLinkElement.Type != BaseLinkElement.LineType.UShape ? originElement.DisplayedNode.NodeDirection :
+							originElement.DisplayedNode.NodeDirection == NodeDirection.Up ? NodeDirection.Down : NodeDirection.Up;
 
 			void ProcessNodeRequest(object o, RecipeRequestArgs recipeRequestArgs)
 			{
@@ -322,11 +322,11 @@ namespace Foreman
 		public void AddPassthroughNodesFromSelection(LinkType linkType, Size offset)
 		{
 			List<BaseNodeElement> newPassthroughNodes = new List<BaseNodeElement>();
-			foreach(PassthroughNodeElement passthroughNode in selectedNodes)
+			foreach (PassthroughNodeElement passthroughNode in selectedNodes)
 			{
 				NodeDirection newNodeDirection = !SmartNodeDirection ? Graph.DefaultNodeDirection :
-					draggedLinkElement.Type != BaseLinkElement.LineType.UShape ? passthroughNode.DisplayedNode.NodeDirection :
-					passthroughNode.DisplayedNode.NodeDirection == NodeDirection.Up ? NodeDirection.Down : NodeDirection.Up;
+								draggedLinkElement.Type != BaseLinkElement.LineType.UShape ? passthroughNode.DisplayedNode.NodeDirection :
+								passthroughNode.DisplayedNode.NodeDirection == NodeDirection.Up ? NodeDirection.Down : NodeDirection.Up;
 
 				Item passthroughItem = ((ReadOnlyPassthroughNode)passthroughNode.DisplayedNode).PassthroughItem;
 
@@ -339,9 +339,9 @@ namespace Foreman
 				controller.SetDirection(newNodeDirection);
 
 				if (linkType == LinkType.Input)
-					Graph.CreateLink(newNode, passthroughNode.DisplayedNode, passthroughItem );
+					Graph.CreateLink(newNode, passthroughNode.DisplayedNode, passthroughItem);
 				else
-					Graph.CreateLink(passthroughNode.DisplayedNode, newNode, passthroughItem );
+					Graph.CreateLink(passthroughNode.DisplayedNode, newNode, passthroughItem);
 
 				newPassthroughNodes.Add(nodeElementDictionary[newNode]);
 			}
@@ -395,8 +395,8 @@ namespace Foreman
 			Point screenOriginPoint = GraphToScreen(new Point(bNodeElement.X - (bNodeElement.Width / 2), bNodeElement.Y));
 			screenOriginPoint = new Point(screenOriginPoint.X - editPanel.Width, screenOriginPoint.Y - (editPanel.Height / 2));
 			Point offset = new Point(
-				(int)(Math.Min(Math.Max(0, 25 - screenOriginPoint.X), this.Width - screenOriginPoint.X - editPanel.Width - bNodeElement.Width - 25)),
-				(int)(Math.Min(Math.Max(0, 25 - screenOriginPoint.Y), this.Height - screenOriginPoint.Y - editPanel.Height - 25)));
+							(int)(Math.Min(Math.Max(0, 25 - screenOriginPoint.X), this.Width - screenOriginPoint.X - editPanel.Width - bNodeElement.Width - 25)),
+							(int)(Math.Min(Math.Max(0, 25 - screenOriginPoint.Y), this.Height - screenOriginPoint.Y - editPanel.Height - 25)));
 
 			ViewOffset = Point.Add(ViewOffset, new Size((int)(offset.X / ViewScale), (int)(offset.Y / ViewScale)));
 			UpdateGraphBounds();
@@ -431,8 +431,8 @@ namespace Foreman
 				recipeEditPanelOriginPoint.Y += editPanel.Height / 2 - 125;
 				recipeEditPanelOriginPoint.X -= recipePanel.Width + 5;
 				Point offset = new Point(
-					(int)(Math.Min(Math.Max(0, 25 - recipeEditPanelOriginPoint.X), this.Width - recipeEditPanelOriginPoint.X - editPanel.Width)),
-					(int)(Math.Min(Math.Max(0, 25 - recipeEditPanelOriginPoint.Y), this.Height - recipeEditPanelOriginPoint.Y - editPanel.Height - 25)));
+								(int)(Math.Min(Math.Max(0, 25 - recipeEditPanelOriginPoint.X), this.Width - recipeEditPanelOriginPoint.X - editPanel.Width)),
+								(int)(Math.Min(Math.Max(0, 25 - recipeEditPanelOriginPoint.Y), this.Height - recipeEditPanelOriginPoint.Y - editPanel.Height - 25)));
 
 				editPanel.Location = Point.Add(recipeEditPanelOriginPoint, (Size)offset);
 				recipePanel.Location = new Point(editPanel.Location.X + editPanel.Width + 5, editPanel.Location.Y);
@@ -555,7 +555,7 @@ namespace Foreman
 			selectionPen.Width = 2 / ViewScale;
 
 			//grid
-			if(!FullGraph)
+			if (!FullGraph)
 				Grid.Paint(graphics, ViewScale, VisibleGraphBounds, (currentDragOperation == DragOperation.Item) ? MouseDownElement as BaseNodeElement : null);
 
 			//process link element widths
@@ -594,7 +594,7 @@ namespace Foreman
 			//paint all elements (nodes & lines)
 			int visibleElements = GetPaintingOrder().Count(e => e.Visible && e is BaseNodeElement);
 			foreach (GraphElement element in GetPaintingOrder())
-				element.Paint(graphics, FullGraph? NodeDrawingStyle.PrintStyle : IconsOnly? NodeDrawingStyle.IconsOnly : (visibleElements > NodeCountForSimpleView || ViewScale < 0.2)? NodeDrawingStyle.Simple : NodeDrawingStyle.Regular); //if viewscale is 0.2, then the text, images, etc being drawn are ~1/5th the size: aka: ~6x6 pixel images, etc. Use simple draw. Also simple draw if too many objects
+				element.Paint(graphics, FullGraph ? NodeDrawingStyle.PrintStyle : IconsOnly ? NodeDrawingStyle.IconsOnly : (visibleElements > NodeCountForSimpleView || ViewScale < 0.2) ? NodeDrawingStyle.Simple : NodeDrawingStyle.Regular); //if viewscale is 0.2, then the text, images, etc being drawn are ~1/5th the size: aka: ~6x6 pixel images, etc. Use simple draw. Also simple draw if too many objects
 
 			//selection zone
 			if (currentDragOperation == DragOperation.Selection && !FullGraph)
@@ -744,18 +744,18 @@ namespace Foreman
 
 						rightClickMenu.MenuItems.Clear();
 						rightClickMenu.MenuItems.Add(new MenuItem("Add Item",
-							new EventHandler((o, ee) =>
-							{
-								AddItem(screenPoint, ScreenToGraph(e.Location));
-							})));
+										new EventHandler((o, ee) =>
+										{
+											AddItem(screenPoint, ScreenToGraph(e.Location));
+										})));
 						rightClickMenu.MenuItems.Add(new MenuItem("Add Recipe",
-							new EventHandler((o, ee) =>
-							{
-								AddRecipe(screenPoint, null, ScreenToGraph(e.Location), NewNodeType.Disconnected);
-							})));
+										new EventHandler((o, ee) =>
+										{
+											AddRecipe(screenPoint, null, ScreenToGraph(e.Location), NewNodeType.Disconnected);
+										})));
 						rightClickMenu.Show(this, e.Location);
 					}
-					else if(currentDragOperation != DragOperation.Selection)
+					else if (currentDragOperation != DragOperation.Selection)
 						element?.MouseUp(graph_location, e.Button, (currentDragOperation == DragOperation.Item));
 					break;
 				case MouseButtons.Middle:
@@ -1065,10 +1065,10 @@ namespace Foreman
 			}
 
 			VisibleGraphBounds = new Rectangle(
-				(int)(-Width / (2 * ViewScale) - ViewOffset.X),
-				(int)(-Height / (2 * ViewScale) - ViewOffset.Y),
-				(int)(Width / ViewScale),
-				(int)(Height / ViewScale));
+							(int)(-Width / (2 * ViewScale) - ViewOffset.X),
+							(int)(-Height / (2 * ViewScale) - ViewOffset.Y),
+							(int)(Width / ViewScale),
+							(int)(Height / ViewScale));
 		}
 
 		private void ProductionGraphViewer_Resize(object sender, EventArgs e)
@@ -1232,7 +1232,7 @@ namespace Foreman
 					else
 					{
 						//errors found. even though the name fits, but the preset seems to be the wrong one. Proceed with searching for best-fit
-						if(errors != null)
+						if (errors != null)
 							presetErrors.Add(errors);
 						allPresets.Remove(savedWPreset);
 					}

--- a/Foreman/packages.config
+++ b/Foreman/packages.config
@@ -3,4 +3,5 @@
   <package id="Google.OrTools" version="9.1.9490" targetFramework="net462" />
   <package id="Google.Protobuf" version="3.18.0" targetFramework="net462" />
   <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net462" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
This adds automatic graph layout to Foreman (see also https://github.com/DanielKote/Foreman2/issues/21). 

At this point this is an experimental change. The base feature works quite well on small graphs, but it needs to be tested and optimized for large graphs. I wouldn't try it on the Seablock example, yet. There are also a lot of improvements that could be done in follow-up changes. IMHO this is already quite useful on small graphs, and I wanted to get feedback before going down the wrong direction.


